### PR TITLE
Fix bootstrap by providing UI init

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,14 +84,16 @@
       });
 
       window.gameUI = {
+        init: (cb) => {
+          showStartScreen();
+          if (typeof cb === 'function') cb();
+        },
         showStartScreen,
         showGameOver,
         updateScore,
         updateLives,
         updateLevel
       };
-
-      showStartScreen();
     });
   </script>
   <script src="bootstrapAppStart.js"></script>


### PR DESCRIPTION
## Summary
- expose `init` method in `gameUI` so bootstrapApp can start without errors

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68561b31a4f083279260e4862e84267c