### PR TITLE
Add missing Alien and Projectile classes

### DIFF
--- a/alien.js
+++ b/alien.js
@@ -1,0 +1,19 @@
+import { Entity } from './entityBaseClass.js';
+
+export default class Alien extends Entity {
+  constructor(x, y, config = {}) {
+    super(x, y, config.width || 40, config.height || 40);
+    this.config = config;
+  }
+
+  update(dt) {
+    // Custom alien movement could go here
+    this.x += (this.config.vx || 0) * dt;
+    this.y += (this.config.vy || 0) * dt;
+  }
+
+  draw(ctx) {
+    ctx.fillStyle = this.config.color || 'lime';
+    ctx.fillRect(this.x, this.y, this.width, this.height);
+  }
+}

--- a/projectile.js
+++ b/projectile.js
@@ -1,0 +1,21 @@
+import { Entity } from './entityBaseClass.js';
+
+export class Projectile extends Entity {
+  constructor(x, y, options = {}) {
+    super(x, y, options.width || 4, options.height || 10);
+    this.vy = options.speed || -300;
+    this.config = options;
+  }
+
+  update(dt) {
+    this.y += this.vy * dt;
+    if (this.y + this.height < 0) {
+      this.alive = false;
+    }
+  }
+
+  draw(ctx) {
+    ctx.fillStyle = this.config.color || 'white';
+    ctx.fillRect(this.x - this.width / 2, this.y, this.width, this.height);
+  }
+}


### PR DESCRIPTION
## Summary
- add `Alien` entity
- add `Projectile` entity

## Testing
- `node -e "import('./alien.js').then(() => console.log('alien ok')).catch(err => console.error(err))"`
- `node -e "import('./projectile.js').then(() => console.log('proj ok')).catch(err => console.error(err))"`

------
https://chatgpt.com/codex/tasks/task_e_68561f479130832795d005b3650224c4