### PR TITLE
Fix HUD overlay styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     <canvas id="game-canvas" width="800" height="600" role="application" aria-label="Game Canvas">
       Your browser does not support the HTML5 canvas element.
     </canvas>
-    <div id="ui-overlay">
+    <div id="ui-overlay" class="hud">
       <div id="score-container">Score: <span id="score">0</span></div>
       <div id="lives-container">Lives: <span id="lives">3</span></div>
       <div id="level-container">Level: <span id="level">1</span></div>

--- a/styles.css
+++ b/styles.css
@@ -40,6 +40,15 @@ body {
   border-bottom: 2px solid var(--accent-green);
 }
 
+/* HUD overlay container */
+#ui-overlay {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  pointer-events: none;
+  color: white;
+}
+
 .hud {
   position: absolute;
   top: 0;


### PR DESCRIPTION
## Summary
- position `#ui-overlay` over the canvas
- hook HUD overlay into existing `.hud` styling

## Testing
- `node main.js` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6856321e4be8832798c30efb1e0417f2