### PR TITLE
Add sprite support and expose loaded assets

### DIFF
--- a/alien.js
+++ b/alien.js
@@ -13,7 +13,17 @@ export default class Alien extends Entity {
   }
 
   draw(ctx) {
-    ctx.fillStyle = this.config.color || 'lime';
-    ctx.fillRect(this.x, this.y, this.width, this.height);
+    if (this.config.image instanceof HTMLImageElement) {
+      ctx.drawImage(
+        this.config.image,
+        this.x,
+        this.y,
+        this.width,
+        this.height
+      );
+    } else {
+      ctx.fillStyle = this.config.color || 'lime';
+      ctx.fillRect(this.x, this.y, this.width, this.height);
+    }
   }
 }

--- a/bootstrapAppStart.js
+++ b/bootstrapAppStart.js
@@ -42,7 +42,9 @@ async function initEngine() {
   }
 
   if (overlay) overlay.classList.remove('overlay--hidden');
-  await preloadGameAssets(onProgress);
+  const loadedAssets = await preloadGameAssets(onProgress);
+  // make them available to the rest of the game:
+  window.gameAssets = loadedAssets;
   if (overlay) overlay.classList.add('overlay--hidden');
 
   const result = engine.init();

--- a/bulletLifecycleManager.js
+++ b/bulletLifecycleManager.js
@@ -5,13 +5,15 @@ class Bullet {
   /**
    * @param {number} x - Initial x-coordinate.
    * @param {number} y - Initial y-coordinate.
+   * @param {object} [options]
    */
-  constructor(x, y) {
+  constructor(x, y, options = {}) {
     this.x = x;
     this.y = y;
     this.radius = 2;
     this.speed = 300; // pixels per second
     this.isAlive = true;
+    this.image = options.image;
   }
 
   /**
@@ -30,9 +32,19 @@ class Bullet {
    * @param {CanvasRenderingContext2D} ctx
    */
   draw(ctx) {
-    ctx.beginPath();
-    ctx.arc(this.x, this.y, this.radius, 0, Math.PI * 2);
-    ctx.fill();
+    if (this.image instanceof HTMLImageElement) {
+      ctx.drawImage(
+        this.image,
+        this.x - this.image.width / 2,
+        this.y - this.image.height / 2,
+        this.image.width,
+        this.image.height
+      );
+    } else {
+      ctx.beginPath();
+      ctx.arc(this.x, this.y, this.radius, 0, Math.PI * 2);
+      ctx.fill();
+    }
   }
 }
 
@@ -51,8 +63,8 @@ class BulletLifecycleManager {
    * @param {number} x
    * @param {number} y
    */
-  shoot(x, y) {
-    this.bullets.push(new Bullet(x, y));
+  shoot(x, y, options = {}) {
+    this.bullets.push(new Bullet(x, y, options));
   }
 
   /**
@@ -90,8 +102,8 @@ class BulletLifecycleManager {
 
 const bulletManager = new BulletLifecycleManager();
 
-export function shoot(x, y) {
-  bulletManager.shoot(x, y);
+export function shoot(x, y, options = {}) {
+  bulletManager.shoot(x, y, options);
 }
 
 export function update(dt) {

--- a/gameLoopManager.js
+++ b/gameLoopManager.js
@@ -23,8 +23,27 @@ function initGame() {
   const canvasRect = canvas.getBoundingClientRect();
   canvasWidth = canvasRect.width;
   canvasHeight = canvasRect.height;
-  player = new Player(canvasWidth / 2, canvasHeight - 40, { canvasWidth });
-  aliens = new AlienGridController(60, 60, 50, 50, { width: 40, height: 30 });
+  player = new Player(
+    canvasWidth / 2,
+    canvasHeight - 40,
+    {
+      canvasWidth,
+      image: window.gameAssets && window.gameAssets.images.playerShip,
+      projectileOptions: { image: window.gameAssets && window.gameAssets.images.laser }
+    }
+  );
+
+  aliens = new AlienGridController(
+    60,
+    60,
+    50,
+    50,
+    {
+      width: 40,
+      height: 30,
+      image: window.gameAssets && window.gameAssets.images.alienBlue
+    }
+  );
   aliens.addAliens(3, 8);
   score = 0;
   lives = 3;

--- a/playerBoundedShooter.js
+++ b/playerBoundedShooter.js
@@ -16,6 +16,7 @@ class Player extends Entity {
     this.cooldown = 0;
     this.projectileOptions = options.projectileOptions || {};
     this.canvasWidth = options.canvasWidth || 800;
+    this.image = options.image;
   }
 
   update(dt) {
@@ -39,19 +40,33 @@ class Player extends Entity {
   }
 
   draw(ctx) {
-    ctx.save();
-    ctx.fillStyle = 'white';
-    ctx.fillRect(
-      this.x - this.width / 2,
-      this.y - this.height / 2,
-      this.width,
-      this.height
-    );
-    ctx.restore();
+    if (this.image instanceof HTMLImageElement) {
+      ctx.drawImage(
+        this.image,
+        this.x - this.width / 2,
+        this.y - this.height / 2,
+        this.width,
+        this.height
+      );
+    } else {
+      ctx.save();
+      ctx.fillStyle = 'white';
+      ctx.fillRect(
+        this.x - this.width / 2,
+        this.y - this.height / 2,
+        this.width,
+        this.height
+      );
+      ctx.restore();
+    }
   }
 
   fire() {
-    bulletManager.shoot(this.x, this.y - this.height / 2);
+    bulletManager.shoot(
+      this.x,
+      this.y - this.height / 2,
+      this.projectileOptions
+    );
   }
 }
 


### PR DESCRIPTION
## Summary
- expose loaded assets globally after preloading
- pass sprite images to the player and aliens when initializing the game
- draw aliens and player using sprites when available
- allow bullets to render sprite images

## Testing
- `node -e "require('./bootstrapAppStart.js');"`
- `node -e "import('./gameLoopManager.js').catch(err => console.error(err));"`
- `node -e "import('./bulletLifecycleManager.js').catch(err => console.error(err));"`


------
https://chatgpt.com/codex/tasks/task_e_6856413f3260832780a66d9d68d42c7a