### PR TITLE
Improve visuals with background and modern HUD

### DIFF
--- a/canvasRenderManager.js
+++ b/canvasRenderManager.js
@@ -9,6 +9,7 @@ export default class CanvasRenderManager {
       throw new Error('2D rendering context not supported or canvas unavailable');
     }
     this.ctx = ctx;
+    this.backgroundImage = null;
     this._handleResize = this._resizeCanvas.bind(this);
     this._handleResize();
     window.addEventListener('resize', this._handleResize);
@@ -25,6 +26,14 @@ export default class CanvasRenderManager {
   clear() {
     const { width, height } = this.canvas.getBoundingClientRect();
     this.ctx.clearRect(0, 0, width, height);
+  }
+
+  setBackgroundImage(img) {
+    if (img instanceof HTMLImageElement) {
+      this.backgroundImage = img;
+    } else {
+      this.backgroundImage = null;
+    }
   }
 
   drawEntities(entities) {
@@ -46,6 +55,10 @@ export default class CanvasRenderManager {
 
   render(state) {
     this.clear();
+    const { width, height } = this.canvas.getBoundingClientRect();
+    if (this.backgroundImage) {
+      this.ctx.drawImage(this.backgroundImage, 0, 0, width, height);
+    }
     if (state.entities && Array.isArray(state.entities)) {
       this.drawEntities(state.entities);
     }

--- a/gameLoopManager.js
+++ b/gameLoopManager.js
@@ -20,6 +20,9 @@ let canvasHeight = 0;
 function initGame() {
   const canvas = document.getElementById('game-canvas');
   renderer = new CanvasRenderManager(canvas);
+  if (window.gameAssets && window.gameAssets.images.background) {
+    renderer.setBackgroundImage(window.gameAssets.images.background);
+  }
   const canvasRect = canvas.getBoundingClientRect();
   canvasWidth = canvasRect.width;
   canvasHeight = canvasRect.height;

--- a/styles.css
+++ b/styles.css
@@ -1,11 +1,11 @@
 :root {
   --hud-font: 'Press Start 2P', sans-serif;
-  --hud-color: #ffffff;
+  --hud-color: #e0e0e0;
   --hud-shadow: 1px 1px 2px rgba(0, 0, 0, 0.7);
-  --background-gradient: radial-gradient(circle at top, #170033, #000000);
+  --background-gradient: radial-gradient(circle at top, #2b2b2b, #000000);
   --accent-green: #00ff99;
   --accent-purple: #8e2bff;
-  --overlay-bg: rgba(0, 0, 0, 0.8);
+  --overlay-bg: rgba(20, 20, 20, 0.8);
   --button-bg: var(--accent-purple);
   --button-color: #ffffff;
   --button-border: var(--accent-green);
@@ -36,7 +36,7 @@ body {
   display: block;
   width: 100%;
   height: auto;
-  background-color: #000000;
+  background-color: transparent;
   border-bottom: 2px solid var(--accent-green);
 }
 
@@ -46,7 +46,22 @@ body {
   top: 10px;
   left: 10px;
   pointer-events: none;
-  color: white;
+  color: var(--hud-color);
+  display: flex;
+  gap: 8px;
+}
+
+#ui-overlay > div {
+  background-color: rgba(50, 50, 50, 0.6);
+  padding: 4px 8px;
+  border-radius: 4px;
+  border: 1px solid var(--accent-purple);
+}
+
+#score-container span,
+#lives-container span,
+#level-container span {
+  color: var(--accent-green);
 }
 
 .hud {


### PR DESCRIPTION
## Summary
- display the loaded background graphic behind the action
- refresh color palette to modern gray while keeping purple and green accents
- style the score, lives and level boxes for a sleeker HUD

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68564510bef0832793651753e6bb9beb