### PR TITLE
Improve HUD layout and scale sprites

### DIFF
--- a/gameLoopManager.js
+++ b/gameLoopManager.js
@@ -30,11 +30,12 @@ function initGame() {
   canvasHeight = canvasRect.height;
   player = new Player(
     canvasWidth / 2,
-    canvasHeight - 40,
+    canvasHeight - 30,
     {
       canvasWidth,
-      image: window.gameAssets && window.gameAssets.images.playerShip,
-      projectileOptions: { image: window.gameAssets && window.gameAssets.images.laser }
+      width: 60,
+      height: 30,
+      image: window.gameAssets && window.gameAssets.images.playerShip
     }
   );
 

--- a/index.html
+++ b/index.html
@@ -9,14 +9,16 @@
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-  <div id="game-container">
-    <canvas id="game-canvas" width="800" height="600" role="application" aria-label="Game Canvas">
-      Your browser does not support the HTML5 canvas element.
-    </canvas>
-    <div id="score-container" class="hud__score">Score: <span id="score">0</span></div>
-    <div id="lives-container" class="hud__lives">Lives: <span id="lives">3</span></div>
-    <div id="level-container" class="hud__level">Level: <span id="level">1</span></div>
-  </div>
+    <div id="game-container">
+      <canvas id="game-canvas" width="800" height="600" role="application" aria-label="Game Canvas">
+        Your browser does not support the HTML5 canvas element.
+      </canvas>
+      <div id="ui-overlay">
+        <div id="score-container" class="hud__score">Score: <span id="score">0</span></div>
+        <div id="lives-container" class="hud__lives">Lives: <span id="lives">3</span></div>
+        <div id="level-container" class="hud__level">Level: <span id="level">1</span></div>
+      </div>
+    </div>
   <div id="loading-overlay" class="overlay overlay--hidden">
     <p>Loading... <span id="loading-progress">0%</span></p>
   </div>

--- a/playerBoundedShooter.js
+++ b/playerBoundedShooter.js
@@ -10,12 +10,10 @@ function clamp(value, min, max) {
 
 class Player extends Entity {
   constructor(x, y, options = {}) {
-    // Slightly larger default ship size
-    super(x, y, options.width || 50, options.height || 30);
+    super(x, y, options.width || 60, options.height || 30);
     this.speed = options.speed || 200;
     this.fireRate = options.fireRate || 0.5;
     this.cooldown = 0;
-    this.projectileOptions = options.projectileOptions || {};
     this.canvasWidth = options.canvasWidth || 800;
     this.image = options.image;
   }
@@ -64,10 +62,9 @@ class Player extends Entity {
 
   fire() {
     bulletManager.shoot(this.x, this.y - this.height / 2, {
-      width: 6,
-      height: 20,
-      image: window.gameAssets && window.gameAssets.images.laser,
-      ...this.projectileOptions
+      width: 8,
+      height: 24,
+      image: window.gameAssets && window.gameAssets.images.laser
     });
   }
 }

--- a/projectile.js
+++ b/projectile.js
@@ -2,9 +2,9 @@ import { Entity } from './entityBaseClass.js';
 
 export class Projectile extends Entity {
   constructor(x, y, options = {}) {
-    super(x, y, options.width || 4, options.height || 10);
-    this.vy = options.speed || -300;
+    super(x, y, options.width || 8, options.height || 24);
     this.image = options.image;
+    this.vy = options.speed || -300;
     this.config = options;
   }
 

--- a/styles.css
+++ b/styles.css
@@ -59,22 +59,23 @@ body {
   font-size: 14px;
 }
 
-.hud__score {
+
+#ui-overlay {
   position: absolute;
   top: 10px;
   left: 10px;
+  display: flex;
+  gap: 40px;
+  pointer-events: none;
+  font-family: var(--hud-font);
+  color: var(--hud-color);
+  text-shadow: var(--hud-shadow);
 }
 
-.hud__lives {
-  position: absolute;
-  top: 10px;
-  left: 140px;
-}
-
+.hud__score,
+.hud__lives,
 .hud__level {
-  position: absolute;
-  top: 10px;
-  left: 270px;
+  position: static;
 }
 
 .hud__lives-icon {


### PR DESCRIPTION
## Summary
- arrange HUD info in new `#ui-overlay` flex row
- style `#ui-overlay` for spacing and remove absolute positioning from HUD items
- enlarge projectile defaults and update player firing logic
- increase player size and adjust init position

## Testing
- `node -e "require('./playerBoundedShooter.js'); require('./projectile.js');"`
- `node -e "require('./gameLoopManager.js');"`

------
https://chatgpt.com/codex/tasks/task_e_68564c5cefd4832789c5f54e9cb8dcda